### PR TITLE
feat(review): persist 'file viewed' state across reloads (sha-keyed, per-PR)

### DIFF
--- a/src/app/(app)/[org]/[repo]/pull/[id]/page.tsx
+++ b/src/app/(app)/[org]/[repo]/pull/[id]/page.tsx
@@ -10,6 +10,7 @@ import { usePR } from '@/features/github/hooks/use-pr';
 import { usePRFiles } from '@/features/github/hooks/use-pr-files';
 import { useReviewStore } from '@/stores/review-store';
 import { useUIStore } from '@/stores/ui-store';
+import { prStorageKey } from '@/lib/review/viewed';
 import { ErrorBoundary } from '@/components/shared/error-boundary';
 import { PageError } from './page-error';
 import { ReviewPalette } from './review-palette';
@@ -24,6 +25,7 @@ export default function PullRequestPage({ params }: Props) {
   const { org, repo, id } = use(params);
   const activeFile = useReviewStore((s) => s.activeFile);
   const setActiveFile = useReviewStore((s) => s.setActiveFile);
+  const hydratePR = useReviewStore((s) => s.hydratePR);
   const conversationOpen = useUIStore((s) => s.conversationOpen);
 
   const prNumber = Number(id);
@@ -41,6 +43,14 @@ export default function PullRequestPage({ params }: Props) {
       setActiveFile(files.data[0].filename);
     }
   }, [files.data, activeFile, setActiveFile]);
+
+  // Reconcile persisted "viewed" state for this PR against the current file
+  // shas whenever the file list loads or changes (e.g. new commits pushed).
+  useEffect(() => {
+    if (files.data) {
+      hydratePR(prStorageKey(org, repo, prNumber), files.data);
+    }
+  }, [files.data, org, repo, prNumber, hydratePR]);
 
   const handleFileSelect = useCallback(
     (path: string) => {

--- a/src/features/diff-viewer/components/multi-file-diff-viewer.tsx
+++ b/src/features/diff-viewer/components/multi-file-diff-viewer.tsx
@@ -304,6 +304,7 @@ function CollapsibleFileHeader({
   const viewedFiles = useReviewStore((s) => s.viewedFiles);
   const toggleFileViewed = useReviewStore((s) => s.toggleFileViewed);
   const isViewed = !!viewedFiles[file.filename];
+  const isStale = useReviewStore((s) => !!s.staleViewedFiles[file.filename]);
 
   const parts = file.filename.split('/');
   const basename = parts.pop() ?? file.filename;
@@ -345,6 +346,16 @@ function CollapsibleFileHeader({
           <span className="text-red-400">-{file.deletions}</span>
         )}
       </div>
+
+      {/* Changed since last viewed */}
+      {isStale && (
+        <span
+          className="shrink-0 rounded-full bg-amber-500/15 px-2 py-0.5 text-[10px] font-medium text-amber-400"
+          title="This file changed since you marked it viewed"
+        >
+          Changed
+        </span>
+      )}
 
       {/* Status badge */}
       <StatusBadge status={file.status} />

--- a/src/features/file-tree/components/file-tree-group.tsx
+++ b/src/features/file-tree/components/file-tree-group.tsx
@@ -10,6 +10,7 @@ interface FileTreeGroupProps {
   selectedFile: string | null;
   expandedPaths: Set<string>;
   viewedFiles: Record<string, boolean>;
+  staleViewedFiles: Record<string, boolean>;
   onFileSelect: (path: string) => void;
   onToggle: (path: string) => void;
   onToggleViewed: (node: FileTreeNodeType) => void;
@@ -21,6 +22,7 @@ export function FileTreeGroup({
   selectedFile,
   expandedPaths,
   viewedFiles,
+  staleViewedFiles,
   onFileSelect,
   onToggle,
   onToggleViewed,
@@ -40,6 +42,7 @@ export function FileTreeGroup({
               isSelected={isSelected}
               isExpanded={isExpanded}
               viewedFiles={viewedFiles}
+              staleViewedFiles={staleViewedFiles}
               onSelect={onFileSelect}
               onToggle={onToggle}
               onToggleViewed={onToggleViewed}
@@ -61,6 +64,7 @@ export function FileTreeGroup({
                       selectedFile={selectedFile}
                       expandedPaths={expandedPaths}
                       viewedFiles={viewedFiles}
+                      staleViewedFiles={staleViewedFiles}
                       onFileSelect={onFileSelect}
                       onToggle={onToggle}
                       onToggleViewed={onToggleViewed}

--- a/src/features/file-tree/components/file-tree-node.tsx
+++ b/src/features/file-tree/components/file-tree-node.tsx
@@ -13,6 +13,7 @@ interface FileTreeNodeProps {
   isSelected: boolean;
   isExpanded: boolean;
   viewedFiles: Record<string, boolean>;
+  staleViewedFiles: Record<string, boolean>;
   onSelect: (path: string) => void;
   onToggle: (path: string) => void;
   onToggleViewed: (node: FileTreeNodeType) => void;
@@ -40,6 +41,7 @@ export function FileTreeNode({
   isSelected,
   isExpanded,
   viewedFiles,
+  staleViewedFiles,
   onSelect,
   onToggle,
   onToggleViewed,
@@ -56,6 +58,9 @@ export function FileTreeNode({
         return paths.length > 0 && paths.every((p) => viewedFiles[p]);
       })()
     : !!viewedFiles[node.path];
+
+  // A file marked viewed whose content changed since (only meaningful for files).
+  const isStale = !isDirectory && !!staleViewedFiles[node.path];
 
   const handleClick = () => {
     if (isDirectory) {
@@ -117,8 +122,16 @@ export function FileTreeNode({
         {node.name}
       </span>
 
-      {/* Status dot for files (hidden once viewed) */}
-      {!isDirectory && node.status && !isViewed && (
+      {/* Changed-since-viewed indicator (takes precedence over the status dot) */}
+      {isStale && (
+        <span
+          className="size-1.5 shrink-0 rounded-full bg-amber-400"
+          title="Changed since you marked it viewed"
+        />
+      )}
+
+      {/* Status dot for files (hidden once viewed or when showing the changed dot) */}
+      {!isDirectory && node.status && !isViewed && !isStale && (
         <span
           className={cn(
             "size-1.5 shrink-0 rounded-full",

--- a/src/features/file-tree/components/file-tree.tsx
+++ b/src/features/file-tree/components/file-tree.tsx
@@ -34,6 +34,7 @@ export function FileTree({
   } = useFileTree(files, selectedFile);
 
   const viewedFiles = useReviewStore((s) => s.viewedFiles);
+  const staleViewedFiles = useReviewStore((s) => s.staleViewedFiles);
   const setFilesViewed = useReviewStore((s) => s.setFilesViewed);
   const setActiveFile = useReviewStore((s) => s.setActiveFile);
   const viewedCount = useMemo(
@@ -118,6 +119,7 @@ export function FileTree({
           selectedFile={selectedFile}
           expandedPaths={expandedPaths}
           viewedFiles={viewedFiles}
+          staleViewedFiles={staleViewedFiles}
           onFileSelect={onFileSelect}
           onToggle={toggleDirectory}
           onToggleViewed={handleToggleViewed}

--- a/src/lib/review/viewed.ts
+++ b/src/lib/review/viewed.ts
@@ -1,0 +1,72 @@
+/**
+ * Pure helpers for sha-keyed "viewed file" review state.
+ *
+ * A file is considered "viewed" only while the sha it was marked viewed at
+ * still matches the file's current sha in the PR. If the author pushes a change
+ * to that file, its sha changes and the prior "viewed" mark becomes "stale"
+ * (changed since viewed) — it must NOT count as viewed (GitHub behaviour).
+ */
+
+/** Stable key identifying a PR review session for persistence scoping. */
+export function prStorageKey(
+  org: string,
+  repo: string,
+  prNumber: number,
+): string {
+  return `${org}/${repo}/${prNumber}`;
+}
+
+/** Persisted per-PR record: filePath -> the file sha that was marked viewed. */
+export type ViewedShaMap = Record<string, string>;
+
+/** Current file shas for the loaded PR: filePath -> current sha. */
+export type ShaByPath = Record<string, string>;
+
+export interface ViewedMaps {
+  /** path -> true when the stored sha matches the current sha (genuinely viewed). */
+  viewed: Record<string, boolean>;
+  /** path -> true when marked viewed but the file changed since (stale). */
+  stale: Record<string, boolean>;
+}
+
+/**
+ * Derive the current-PR viewed/stale boolean maps from the persisted sha map
+ * and the current file shas. Paths no longer present in the PR are dropped.
+ */
+export function deriveViewedMaps(
+  storedShas: ViewedShaMap | undefined,
+  currentShas: ShaByPath,
+): ViewedMaps {
+  const viewed: Record<string, boolean> = {};
+  const stale: Record<string, boolean> = {};
+  if (!storedShas) return { viewed, stale };
+
+  for (const [path, viewedSha] of Object.entries(storedShas)) {
+    const currentSha = currentShas[path];
+    if (currentSha === undefined) continue; // file no longer in PR
+    if (currentSha === viewedSha) viewed[path] = true;
+    else stale[path] = true;
+  }
+  return { viewed, stale };
+}
+
+/**
+ * Evict oldest PR entries (object insertion order) beyond `max`, never removing
+ * the current key. Returns the same reference when nothing needs pruning.
+ */
+export function pruneTrackedPrs<T>(
+  byPr: Record<string, T>,
+  currentKey: string,
+  max: number,
+): Record<string, T> {
+  const keys = Object.keys(byPr);
+  if (keys.length <= max) return byPr;
+
+  const next = { ...byPr };
+  for (const k of keys) {
+    if (Object.keys(next).length <= max) break;
+    if (k === currentKey) continue;
+    delete next[k];
+  }
+  return next;
+}

--- a/src/stores/review-store.ts
+++ b/src/stores/review-store.ts
@@ -1,7 +1,14 @@
 import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
 
 import type { DiffViewMode } from '@/features/diff-viewer/types';
 import type { PRCommentSide } from '@/types/pr';
+import {
+  deriveViewedMaps,
+  pruneTrackedPrs,
+  type ShaByPath,
+  type ViewedShaMap,
+} from '@/lib/review/viewed';
 
 interface LineSelection {
   start: number;
@@ -14,6 +21,9 @@ interface CommentAnchor {
   side: PRCommentSide;
 }
 
+/** Max number of PRs whose viewed-state we retain in localStorage. */
+const MAX_TRACKED_PRS = 100;
+
 interface ReviewStore {
   activeFile: string | null;
   viewMode: DiffViewMode;
@@ -24,8 +34,17 @@ interface ReviewStore {
   /** Set of open (expanded) comment threads, keyed as "path:line:side" */
   openCommentThreads: Set<string>;
 
-  /** Files the user has marked as "viewed", keyed by file path */
+  // --- Viewed state (sha-keyed, persisted per PR) ---
+  /** PERSISTED: prKey -> (filePath -> sha the file was viewed at). */
+  viewedByPr: Record<string, ViewedShaMap>;
+  /** The PR currently loaded (transient, not persisted). */
+  currentPrKey: string | null;
+  /** Current file shas for the loaded PR (transient, not persisted). */
+  currentShaByPath: ShaByPath;
+  /** Derived for current PR: path -> genuinely viewed (sha matches). */
   viewedFiles: Record<string, boolean>;
+  /** Derived for current PR: path -> viewed but changed since (stale). */
+  staleViewedFiles: Record<string, boolean>;
 
   setActiveFile: (file: string | null) => void;
   setViewMode: (mode: DiffViewMode) => void;
@@ -33,64 +52,175 @@ interface ReviewStore {
   setPendingCommentAnchor: (anchor: CommentAnchor | null) => void;
   clearPendingCommentAnchor: () => void;
   toggleCommentThread: (threadKey: string) => void;
+
+  /**
+   * Load a PR's persisted viewed-state and reconcile it against the current
+   * file shas. Recomputes `viewedFiles`/`staleViewedFiles`, drops stored paths
+   * no longer in the PR, and prunes old PRs from storage. Call when PR files
+   * load (and on refetch).
+   */
+  hydratePR: (
+    prKey: string,
+    files: Array<{ filename: string; sha: string }>,
+  ) => void;
   toggleFileViewed: (path: string) => void;
   /** Mark/unmark many files at once (e.g. a whole folder). */
   setFilesViewed: (paths: string[], viewed: boolean) => void;
+  /** Clear viewed-state for the currently loaded PR only. */
   clearViewedFiles: () => void;
 }
 
-export const useReviewStore = create<ReviewStore>((set) => ({
-  activeFile: null,
-  viewMode: 'unified',
-  selectedLines: null,
-  pendingCommentAnchor: null,
-  openCommentThreads: new Set<string>(),
-  viewedFiles: {},
+export const useReviewStore = create<ReviewStore>()(
+  persist(
+    (set) => ({
+      activeFile: null,
+      viewMode: 'unified',
+      selectedLines: null,
+      pendingCommentAnchor: null,
+      openCommentThreads: new Set<string>(),
 
-  setActiveFile: (file) =>
-    set({ activeFile: file, selectedLines: null }),
+      viewedByPr: {},
+      currentPrKey: null,
+      currentShaByPath: {},
+      viewedFiles: {},
+      staleViewedFiles: {},
 
-  setViewMode: (mode) => set({ viewMode: mode }),
+      setActiveFile: (file) => set({ activeFile: file, selectedLines: null }),
 
-  setSelectedLines: (lines) => set({ selectedLines: lines }),
+      setViewMode: (mode) => set({ viewMode: mode }),
 
-  setPendingCommentAnchor: (anchor) =>
-    set({ pendingCommentAnchor: anchor }),
+      setSelectedLines: (lines) => set({ selectedLines: lines }),
 
-  clearPendingCommentAnchor: () =>
-    set({ pendingCommentAnchor: null }),
+      setPendingCommentAnchor: (anchor) =>
+        set({ pendingCommentAnchor: anchor }),
 
-  toggleCommentThread: (threadKey) =>
-    set((state) => {
-      const next = new Set(state.openCommentThreads);
-      if (next.has(threadKey)) {
-        next.delete(threadKey);
-      } else {
-        next.add(threadKey);
-      }
-      return { openCommentThreads: next };
+      clearPendingCommentAnchor: () => set({ pendingCommentAnchor: null }),
+
+      toggleCommentThread: (threadKey) =>
+        set((state) => {
+          const next = new Set(state.openCommentThreads);
+          if (next.has(threadKey)) {
+            next.delete(threadKey);
+          } else {
+            next.add(threadKey);
+          }
+          return { openCommentThreads: next };
+        }),
+
+      hydratePR: (prKey, files) =>
+        set((state) => {
+          const currentShaByPath: ShaByPath = {};
+          for (const f of files) currentShaByPath[f.filename] = f.sha;
+
+          const stored = state.viewedByPr[prKey];
+          const { viewed, stale } = deriveViewedMaps(stored, currentShaByPath);
+
+          // Drop stored entries for files no longer in the PR so localStorage
+          // doesn't accumulate dead paths.
+          let nextByPr = state.viewedByPr;
+          if (stored) {
+            const cleaned: ViewedShaMap = {};
+            for (const [path, sha] of Object.entries(stored)) {
+              if (currentShaByPath[path] !== undefined) cleaned[path] = sha;
+            }
+            nextByPr = { ...state.viewedByPr, [prKey]: cleaned };
+          }
+          nextByPr = pruneTrackedPrs(nextByPr, prKey, MAX_TRACKED_PRS);
+
+          return {
+            currentPrKey: prKey,
+            currentShaByPath,
+            viewedFiles: viewed,
+            staleViewedFiles: stale,
+            viewedByPr: nextByPr,
+          };
+        }),
+
+      toggleFileViewed: (path) =>
+        set((state) => {
+          const { currentPrKey, currentShaByPath } = state;
+          if (!currentPrKey) return {};
+          const sha = currentShaByPath[path];
+          if (sha === undefined) return {};
+
+          const prMap = { ...(state.viewedByPr[currentPrKey] ?? {}) };
+          const viewed = { ...state.viewedFiles };
+          const stale = { ...state.staleViewedFiles };
+
+          if (viewed[path]) {
+            delete prMap[path];
+            delete viewed[path];
+          } else {
+            prMap[path] = sha;
+            viewed[path] = true;
+          }
+          delete stale[path]; // toggling always clears the changed-since flag
+
+          return {
+            viewedByPr: { ...state.viewedByPr, [currentPrKey]: prMap },
+            viewedFiles: viewed,
+            staleViewedFiles: stale,
+          };
+        }),
+
+      setFilesViewed: (paths, isViewed) =>
+        set((state) => {
+          const { currentPrKey, currentShaByPath } = state;
+          if (!currentPrKey) return {};
+
+          const prMap = { ...(state.viewedByPr[currentPrKey] ?? {}) };
+          const viewed = { ...state.viewedFiles };
+          const stale = { ...state.staleViewedFiles };
+
+          for (const path of paths) {
+            const sha = currentShaByPath[path];
+            if (sha === undefined) continue;
+            if (isViewed) {
+              prMap[path] = sha;
+              viewed[path] = true;
+            } else {
+              delete prMap[path];
+              delete viewed[path];
+            }
+            delete stale[path];
+          }
+
+          return {
+            viewedByPr: { ...state.viewedByPr, [currentPrKey]: prMap },
+            viewedFiles: viewed,
+            staleViewedFiles: stale,
+          };
+        }),
+
+      clearViewedFiles: () =>
+        set((state) => {
+          const { currentPrKey } = state;
+          if (!currentPrKey) return { viewedFiles: {}, staleViewedFiles: {} };
+          const nextByPr = { ...state.viewedByPr };
+          delete nextByPr[currentPrKey];
+          return {
+            viewedByPr: nextByPr,
+            viewedFiles: {},
+            staleViewedFiles: {},
+          };
+        }),
     }),
-
-  toggleFileViewed: (path) =>
-    set((state) => {
-      const next = { ...state.viewedFiles };
-      if (next[path]) {
-        delete next[path];
-      } else {
-        next[path] = true;
-      }
-      return { viewedFiles: next };
-    }),
-
-  setFilesViewed: (paths, viewed) =>
-    set((state) => {
-      const next = { ...state.viewedFiles };
-      for (const path of paths) {
-        if (viewed) next[path] = true;
-        else delete next[path];
-      }
-      return { viewedFiles: next };
-    }),
-
-  clearViewedFiles: () => set({ viewedFiles: {} }),
-}));
+    {
+      name: 'gitreview:review-viewed',
+      version: 1,
+      // Guard storage so SSR (no window) never touches localStorage.
+      storage: createJSONStorage(() =>
+        typeof window !== 'undefined'
+          ? window.localStorage
+          : {
+              getItem: () => null,
+              setItem: () => {},
+              removeItem: () => {},
+            },
+      ),
+      // Only the durable per-PR sha map is persisted; everything else
+      // (active file, view mode, comment threads, derived maps) is transient.
+      partialize: (state) => ({ viewedByPr: state.viewedByPr }),
+    },
+  ),
+);


### PR DESCRIPTION
## Problem

Marking a file as **viewed** during a PR review was lost on tab reload — the state lived only in an in-memory Zustand map (`viewedFiles`). It was also keyed by filename **globally**, a latent bug that would bleed viewed state across PRs.

## Solution

Persist viewed state to **localStorage**, scoped **per-PR**, and keyed by each file's **content sha** so it stays correct when files change.

- **Persistence (per-browser):** `viewedByPr: Record<prKey, Record<path, sha>>` via zustand `persist` + `partialize` (only this slice is persisted), SSR-guarded storage. `prKey = org/repo/prNumber`.
- **sha-keyed invalidation (GitHub-style):** a file counts as viewed only while the sha it was viewed at still matches the current sha. If the author pushes a change, it's auto-**un-viewed** and flagged **"changed since viewed"** (amber pill in the diff header + amber dot in the file tree).
- **Public store API unchanged** (`viewedFiles` boolean map, `toggleFileViewed`, `setFilesViewed`, `clearViewedFiles`) — consumer components needed minimal changes. shas are resolved internally via a new `hydratePR(prKey, files)` called when PR files load.
- **Fixes the per-PR bleed** bug along the way; storage bounded at `MAX_TRACKED_PRS = 100`.

## Files

- `src/lib/review/viewed.ts` (new) — pure helpers: `prStorageKey`, `deriveViewedMaps`, `pruneTrackedPrs`.
- `src/stores/review-store.ts` — persist + sha-keyed reducers + `hydratePR` + `staleViewedFiles`.
- `src/app/(app)/[org]/[repo]/pull/[id]/page.tsx` — hydrate on files load.
- `multi-file-diff-viewer.tsx`, `file-tree.tsx`, `file-tree-group.tsx`, `file-tree-node.tsx` — "changed since viewed" flag UI.

## Verification

- `npm run typecheck` ✅ · `npm run build` ✅
- Code-reviewed per task + a whole-branch review (state-machine consistency, SSR safety, per-PR isolation, folder aggregation all confirmed).
- ⚠️ **Live browser QA not yet run** (needs an authenticated session on a real PR). Manual matrix: mark viewed → reload → persists; per-PR isolation; stale via editing the `gitreview:review-viewed` localStorage key.

## Notes / accepted by design

- No server sync (per-browser only) — the stubbed `file_review_statuses` DB schema is a clean future upgrade path.
- File **rename** resets viewed (matches GitHub).
- `hydratePR` writes localStorage on each `files.data` change — negligible (tiny payload, off render path); left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)