### PR TITLE
fix(amplify): enable pnpm via Corepack in build spec

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -1,0 +1,19 @@
+version: 1
+frontend:
+  phases:
+    preBuild:
+      commands:
+        - corepack enable
+        - corepack prepare pnpm@11.7.0 --activate
+        - pnpm install --frozen-lockfile
+    build:
+      commands:
+        - pnpm run build
+  artifacts:
+    baseDirectory: .next
+    files:
+      - '**/*'
+  cache:
+    paths:
+      - .next/cache/**/*
+      - node_modules/**/*

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "gitreview",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "pnpm@11.7.0",
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
## Problem

AWS Amplify hosting build fails at `preBuild`:

```
# Executing command: pnpm install
pnpm: command not found
Error: Command failed with exit code 127
```

Amplify auto-detects `pnpm-lock.yaml` and runs `pnpm install`, but the default Amplify build image has no `pnpm` on PATH, so the build dies before any app step runs.

## Fix

- **`amplify.yml`** (new): explicit build spec that activates pnpm through **Corepack** (ships with the Amplify Node runtime — no global install needed) before `pnpm install --frozen-lockfile`, then `pnpm run build`. Caches `.next/cache` and `node_modules`.
- **`package.json`**: pin `"packageManager": "pnpm@11.7.0"` so Corepack provisions the matching version.

## Notes / follow-ups (not in this PR)

- Next.js 16 + React 19 on Amplify SSR may need adapter validation if the build now progresses past install.
- Runtime env/secrets (`DATABASE_URL`, `AUTH_SECRET`, Redis URL, etc.) must be set in the Amplify console — the build log showed empty SSM params.

🤖 Generated with [Claude Code](https://claude.com/claude-code)